### PR TITLE
Add the missing methods and props to the BaseEditorComponent.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4078,9 +4078,9 @@
       "dev": true
     },
     "handlebars": {
-      "version": "4.1.2",
-      "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.1.2.tgz",
-      "integrity": "sha512-nvfrjqvt9xQ8Z/w0ijewdD/vvWDTOweBUm96NTr66Wfvo1mJenBLwcYmPs3TIBP5ruzYGD7Hx/DaM9RmhroGPw==",
+      "version": "4.4.5",
+      "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.4.5.tgz",
+      "integrity": "sha512-0Ce31oWVB7YidkaTq33ZxEbN+UDxMMgThvCe8ptgQViymL5DPis9uLdTA13MiRPhgvqyxIegugrP97iK3JeBHg==",
       "dev": true,
       "requires": {
         "neo-async": "^2.6.0",

--- a/src/BaseEditorComponent.vue
+++ b/src/BaseEditorComponent.vue
@@ -14,6 +14,7 @@
     originalValue = null;
     cellProperties = null;
     state = null;
+    hot = null;
 
     mounted() {
       const _this = this;
@@ -152,6 +153,14 @@
 
     clearHooks(...args) {
       return (Handsontable.editors.BaseEditor.prototype as any).clearHooks.call(this.$data.hotCustomEditorInstance, ...args);
+    }
+
+    getEditedCell(...args) {
+      return (Handsontable.editors.BaseEditor.prototype as any).getEditedCell.call(this.$data.hotCustomEditorInstance, ...args);
+    }
+
+    getEditedCellsZIndex(...args) {
+      return (Handsontable.editors.BaseEditor.prototype as any).getEditedCellsZIndex.call(this.$data.hotCustomEditorInstance, ...args);
     }
   }
 


### PR DESCRIPTION
### Description
Add the missing methods and properties from `Handsontable._editors.Base` to the `BaseEditorComponent`:
 
Added:
- The `hot` property,
- The `getEditedCell` method,
- The `getEditedCellsZIndex` method.

### Related issue(s):
1. #138 

