### PR TITLE
Modify the way table data updates.

### DIFF
--- a/src/HotTable.vue
+++ b/src/HotTable.vue
@@ -34,8 +34,8 @@
 
         // If the dataset dimensions change, update the index mappers.
         if (
-          (newData && newData.length !== this.hotInstance.countRows()) ||
-          (newData && newData[0] && newData[0]?.length !== this.hotInstance.countCols())
+          (newData && newData.length !== this.hotInstance.countSourceRows()) ||
+          (newData && newData[0] && newData[0]?.length !== this.hotInstance.countSourceCols())
         ) {
           this.trimHotMappersToSize(newData);
         }
@@ -104,8 +104,8 @@
       trimHotMappersToSize: function (data: any[][]): void {
         const rowsToRemove: number[] = [];
         const columnsToRemove: number[] = [];
-        const hotRowCount: number = this.hotInstance.countRows();
-        const hotColumnCount: number = this.hotInstance.countCols();
+        const hotRowCount: number = this.hotInstance.countSourceRows();
+        const hotColumnCount: number = this.hotInstance.countSourceCols();
 
         if (data.length) {
           if (data.length < hotRowCount) {

--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -137,23 +137,35 @@ export function filterPassedProps(props) {
 /**
  * Prepare the settings object to be used as the settings for Handsontable, based on the props provided to the component.
  *
- * @param {Object} props The props passed to the component.
- * @returns {Object} An object containing the properties, ready to be used within Handsontable.
+ * @param {HotTableProps} props The props passed to the component.
+ * @param {Handsontable.GridSettings} currentSettings The current Handsontable settings.
+ * @returns {Handsontable.GridSettings} An object containing the properties, ready to be used within Handsontable.
  */
-export function prepareSettings(props: HotTableProps): Handsontable.GridSettings {
+export function prepareSettings(props: HotTableProps, currentSettings?: Handsontable.GridSettings): Handsontable.GridSettings {
   const assignedProps: VueProps<HotTableProps> = filterPassedProps(props);
   const hotSettingsInProps: {} = props.settings ? props.settings : assignedProps;
   const additionalHotSettingsInProps: Handsontable.GridSettings = props.settings ? assignedProps : null;
   const newSettings = {};
 
   for (const key in hotSettingsInProps) {
-    if (hotSettingsInProps.hasOwnProperty(key) && hotSettingsInProps[key] !== void 0) {
+    if (
+      hotSettingsInProps.hasOwnProperty(key) &&
+      hotSettingsInProps[key] !== void 0 &&
+      ((currentSettings && key !== 'data') ? !simpleEqual(currentSettings[key], hotSettingsInProps[key]) : true)
+    ) {
       newSettings[key] = hotSettingsInProps[key];
     }
   }
 
   for (const key in additionalHotSettingsInProps) {
-    if (key !== 'id' && key !== 'settings' && key !== 'wrapperRendererCacheSize' && additionalHotSettingsInProps.hasOwnProperty(key) && additionalHotSettingsInProps[key] !== void 0) {
+    if (
+      additionalHotSettingsInProps.hasOwnProperty(key) &&
+      key !== 'id' &&
+      key !== 'settings' &&
+      key !== 'wrapperRendererCacheSize' &&
+      additionalHotSettingsInProps[key] !== void 0 &&
+      ((currentSettings && key !== 'data') ? !simpleEqual(currentSettings[key], additionalHotSettingsInProps[key]) : true)
+    ) {
       newSettings[key] = additionalHotSettingsInProps[key];
     }
   }
@@ -220,4 +232,17 @@ export function createVueComponent(vNode: VNode, parent: Vue, props: object, dat
   bulkComponentContainer.appendChild(componentContainer);
 
   return (new (vNode.componentOptions as any).Ctor(settings)).$mount(componentContainer);
+}
+
+/**
+ * Compare two objects using `JSON.stringify`.
+ * *Note: * As it's using the stringify function to compare objects, the property order in both objects is
+ * important. It will return `false` for the same objects, if they're defined in a different order.
+ *
+ * @param {object} objectA First object to compare.
+ * @param {object} objectB Second object to compare.
+ * @returns {boolean} `true` if they're the same, `false` otherwise.
+ */
+function simpleEqual(objectA, objectB) {
+  return JSON.stringify(objectA) === JSON.stringify(objectB);
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -16,7 +16,8 @@ export interface HotTableMethods {
   getGlobalRendererVNode: () => VNode | void,
   getGlobalEditorVNode: () => VNode | void,
   getRendererWrapper: (vNode: VNode, containerComponent: Vue) => (...args) => HTMLElement,
-  getEditorClass: (vNode: VNode, containerComponent: Vue) => typeof Handsontable.editors.BaseEditor
+  getEditorClass: (vNode: VNode, containerComponent: Vue) => typeof Handsontable.editors.BaseEditor,
+  trimHotMappersToSize: (data: any[][]) => void
 }
 
 export interface HotTableProps extends Handsontable.GridSettings {

--- a/test/hotTable.spec.ts
+++ b/test/hotTable.spec.ts
@@ -98,7 +98,8 @@ describe('Updating the Handsontable settings', () => {
     expect(hotTableComponent.hotInstance.getSettings().readOnly).toEqual(false);
   });
 
-  it('should update the previously initialized Handsontable instance with only the options that are passed to the component as props', async() => {
+  it('should update the previously initialized Handsontable instance with only the options that are passed to the' +
+    ' component as props and actually changed', async() => {
     let newHotSettings = null;
     let App = Vue.extend({
       data: function () {
@@ -140,7 +141,46 @@ describe('Updating the Handsontable settings', () => {
 
     await Vue.nextTick();
 
-    expect(Object.keys(newHotSettings).length).toBe(5)
+    expect(Object.keys(newHotSettings).length).toBe(3)
+  });
+
+  it('should not call Handsontable\'s `updateSettings` method, when the table data was changed by reference', async() => {
+    let newHotSettings = null;
+    let App = Vue.extend({
+      data: function () {
+        return {
+          data: [[1, 2, 3]],
+        }
+      },
+      methods: {
+        updateData: function () {
+          this.data.push([2, 3, 4]);
+        }
+      },
+      render(h) {
+        // HotTable
+        return h(HotTable, {
+          ref: 'hotInstance',
+          props: {
+            data: this.data,
+            afterUpdateSettings: function (newSettings) {
+              newHotSettings = newSettings
+            }
+          }
+        })
+      }
+    });
+
+    let testWrapper = mount(App, {
+      sync: false
+    });
+
+    testWrapper.vm.updateData();
+
+    await Vue.nextTick();
+
+    expect(testWrapper.vm.$children[0].hotInstance.getData()).toEqual([[1, 2, 3], [2, 3, 4]]);
+    expect(newHotSettings).toBe(null);
   });
 });
 


### PR DESCRIPTION
### Context
- Make the wrapper NOT call Handsontable's `updateSettings` when the table data updates, update the index mappers instead, as the data itself is synchronized by reference,
- Add a simple diff function to prevent updating with the props which were not changed (might be removed after updating to Vue 3)

### How has this been tested?
- Modified a test case and add another one for the data-updating part of the issue.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

### Related issue(s):
1. #185 