### PR TITLE
Add a test case for using the editors with and without the "key" property at the same time.

### DIFF
--- a/test/hotTable.spec.ts
+++ b/test/hotTable.spec.ts
@@ -1,5 +1,4 @@
 import HotTable from '../src/HotTable.vue';
-import HotColumn from '../src/HotColumn.vue';
 import BaseEditorComponent from '../src/BaseEditorComponent.vue';
 import { mount } from '@vue/test-utils';
 import {
@@ -603,58 +602,6 @@ it('should be possible to pass props to the editor and renderer components', () 
 
   expect(hotTableComponent.rendererCache.get('0-0').component.$props.testProp).toEqual('test-prop-value');
   expect(hotTableComponent.editorCache.get('EditorComponent').$props.testProp).toEqual('test-prop-value');
-
-  testWrapper.destroy();
-});
-
-it('should be possible to set a key on custom editor to use the same component twice', () => {
-  const dummyEditorComponent = Vue.component('renderer-component', {
-    name: 'EditorComponent',
-    extends: BaseEditorComponent,
-    props: ['test-prop'],
-    render: function (h) {
-      return h('div', {});
-    }
-  });
-
-  let App = Vue.extend({
-    render(h) {
-      // HotTable
-      return h(HotTable, {
-        props: {
-          data: createSampleData(2, 2),
-          licenseKey: 'non-commercial-and-evaluation',
-        }
-      }, [
-        h(HotColumn, {}, [
-          h(dummyEditorComponent, {
-            key: 'editor-one',
-            attrs: {
-              'hot-editor': true,
-              'test-prop': 'test-prop-value-1'
-            }
-          }),
-        ]),
-        h(HotColumn, {}, [
-          h(dummyEditorComponent, {
-            key: 'editor-two',
-            attrs: {
-              'hot-editor': true,
-              'test-prop': 'test-prop-value-2'
-            }
-          })
-        ])
-      ])
-    }
-  });
-
-  let testWrapper = mount(App, {
-    attachTo: createDomContainer()
-  });
-  const hotTableComponent = testWrapper.vm.$children[0];
-
-  expect(hotTableComponent.editorCache.get('EditorComponent:editor-one').$props.testProp).toEqual('test-prop-value-1');
-  expect(hotTableComponent.editorCache.get('EditorComponent:editor-two').$props.testProp).toEqual('test-prop-value-2');
 
   testWrapper.destroy();
 });


### PR DESCRIPTION
### Context
- Move the #178 test case to the 'HotColumn' section.
- Add a test for mixing the key-enabled and default editors between columns.

### Related issue(s):
1. #178 
