### PR TITLE
Fix #7599: Adding/updating a property in settings is not used when property is a function

### DIFF
--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -245,5 +245,9 @@ export function createVueComponent(vNode: VNode, parent: Vue, props: object, dat
  * @returns {boolean} `true` if they're the same, `false` otherwise.
  */
 function simpleEqual(objectA, objectB) {
+  if (typeof objectA === 'function' && typeof objectB === 'function') {
+    return ''+objectA === ''+objectB;
+  }
+
   return JSON.stringify(objectA) === JSON.stringify(objectB);
 }

--- a/test/hotTable.spec.ts
+++ b/test/hotTable.spec.ts
@@ -49,6 +49,33 @@ describe('Updating the Handsontable settings', () => {
     expect(testWrapper.vm.hotInstance.getSettings().rowHeaders).toEqual(false);
   });
 
+  it('should update the previously initialized Handsontable instance with a single changed property (function)', async() => {
+    let updateSettingsCalls = 0;
+    const cellsFuncA = function() {}
+    const cellsFuncB = function() {}
+    let testWrapper = mount(HotTable, {
+      propsData: {
+        data: createSampleData(1, 1),
+        licenseKey: 'non-commercial-and-evaluation',
+        cells: cellsFuncA,
+        afterUpdateSettings: function () {
+          updateSettingsCalls++;
+        }
+      }
+    });
+
+    expect(testWrapper.vm.hotInstance.getSettings().cells).toEqual(cellsFuncA);
+
+    testWrapper.setProps({
+      cells: cellsFuncB
+    });
+
+    await Vue.nextTick();
+
+    expect(updateSettingsCalls).toEqual(1);
+    expect(testWrapper.vm.hotInstance.getSettings().cells).toEqual(cellsFuncB);
+  });
+
   it('should update the previously initialized Handsontable instance only once with multiple changed properties', async() => {
     let App = Vue.extend({
       data: function () {


### PR DESCRIPTION
### Context
<!--- Why is this change required? What problem does it solve? -->
When updating a function in the settings object after initializing the grid, the new function is not used.

This PR correct the simpleEqual method in helpers.js.

### How has this been tested?
<!--- Please describe in detail how you tested your changes. -->
The following demos highlight the issue and correction :
* @handsontable/vue 4.1.1: https://jsfiddle.net/Lxdc950k/2/ 👍 
* @handonstable/vue 5.1.0 https://jsfiddle.net/541q03zp/ 👎 
* this version : https://jsfiddle.net/f219rvu6/ 👍 

The PR also add a unit test.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

### Related issue(s):
1. https://github.com/handsontable/handsontable/issues/7599

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project,
- [ ] My change requires a change to the documentation.
